### PR TITLE
Chore/gather all any path

### DIFF
--- a/src/dirname/index.js
+++ b/src/dirname/index.js
@@ -1,0 +1,10 @@
+const { extname: pathExtname, dirname: pathDirname } = require('path');
+
+// dirname : String -> String
+const dirname = path =>
+  pathExtname(path)
+    ? pathDirname(path)
+    : path;
+
+
+module.exports = dirname;

--- a/src/dirname/index.test.js
+++ b/src/dirname/index.test.js
@@ -1,0 +1,22 @@
+/* global describe it expect */
+
+const dirname = require('./');
+
+describe('dirname', () => {
+  it('should be a function', () => {
+    expect(typeof dirname).toBe('function');
+  });
+
+  const pathsAndDirnames = [
+    [ '', '' ],
+    [ 'folder', 'folder' ],
+    [ 'folder/index.js', 'folder' ],
+    [ 'folder/deeper', 'folder/deeper' ],
+    [ 'folder/deeper', 'folder/deeper' ],
+  ];
+  pathsAndDirnames.map(([path, expectedDirname]) =>
+    it(`should return '${expectedDirname}' when given '${path}'`, () =>
+      expect(dirname(path)).toBe(expectedDirname)
+    )
+  );
+});

--- a/src/follow-exports/index.js
+++ b/src/follow-exports/index.js
@@ -1,12 +1,9 @@
 /* global Promise */
 
-const {
-  join: pathJoin,
-  extname: pathExtname,
-  dirname: pathDirname
-} = require('path');
+const { join: pathJoin } = require('path');
 
 const parse = require('../parser/parse');
+const dirname = require('../dirname');
 const visit = require('../parser/visit');
 const readFile = require('../read-file');
 const resolveNodeModulesPath = require('../resolve-node-modules');
@@ -23,9 +20,7 @@ const resolvePath = (cwd, relativePath) => {
 
   return relativePath.startsWith('.')
     ? Promise.resolve(pathJoin(
-      pathExtname(cwd)
-        ? pathDirname(cwd)
-        : cwd,
+      dirname(cwd),
       desiredPath
     ))
     : resolveNodeModulesPath(cwd, desiredPath);

--- a/src/gather-all/index.js
+++ b/src/gather-all/index.js
@@ -1,6 +1,7 @@
 /* global Promise */
 
 const pathJoin = require('path').join;
+const dirname = require('../dirname');
 const readFolder = require('../read-folder');
 const readFile = require('../read-file');
 const metadataParser = require('../metadata-parser');
@@ -14,13 +15,11 @@ const containsFile = files => name => {
     : Promise.reject();
 };
 
-
 // isPath : String -> Promise
 const isPath = path =>
   path
     ? Promise.resolve(path)
     : Promise.reject('Error: gatherAll is missing required `path` argument');
-
 
 // error : String -> Promise
 const error = message =>
@@ -29,19 +28,26 @@ const error = message =>
 
 const gatherAll = path =>
   isPath(path)
-    .then(readFolder)
+    .then(metadataParser)
 
-    .then(files => {
-      const metadata = metadataParser(path)
-        .catch(e =>
-          error(`Unable to parse component in path "${path}", reason: ${e}`)
-        );
+    .catch(e =>
+      error(`Unable to parse component in path "${path}", reason: ${e}`)
+    )
 
+    .then(metadata =>
+      Promise.all([
+        Promise.resolve(metadata),
+        readFolder(path)
+      ])
+    )
+
+    .then(([metadata, files]) => {
       const readMarkdown = markdownPath =>
         containsFile(files)(markdownPath)
-          .then(file => readFile(pathJoin(path, file)))
+          .then(file => readFile(pathJoin(dirname(path), file)))
           .then(({source}) => source)
           .catch(() => Promise.resolve(''));
+
 
       const readme = readMarkdown('readme.md');
       const readmeAccessibility = readMarkdown('readme.accessibility.md');

--- a/src/gather-all/index.js
+++ b/src/gather-all/index.js
@@ -28,10 +28,15 @@ const error = message =>
 
 const gatherAll = path =>
   isPath(path)
-    .then(metadataParser)
+    .catch(e => {
+      throw e;
+    })
 
-    .catch(e =>
-      error(`Unable to parse component in path "${path}", reason: ${e}`)
+    .then(path =>
+      metadataParser(path)
+        .catch(e =>
+          error(`Unable to parse component in path "${path}", reason: ${e}`)
+        )
     )
 
     .then(metadata =>

--- a/src/gather-all/index.test.js
+++ b/src/gather-all/index.test.js
@@ -243,6 +243,25 @@ describe('gatherAll', () => {
         });
       });
     });
+
+    describe('which is path to concrete file', () => {
+      it('should resolve with component metadata', () => {
+        fs.__setFS({
+          'index.js': componentSourceMock,
+          'readme.md': readmeMock,
+          'readme.accessibility.md': readmeAccessibilityMock,
+          'readme.testkit.md': readmeTestkitMock
+
+        });
+
+        return expect(gatherAll('index.js')).resolves.toEqual({
+          ...metadataMock,
+          readme: readmeMock,
+          readmeAccessibility: readmeAccessibilityMock,
+          readmeTestkit: readmeTestkitMock
+        });
+      });
+    });
   });
 
   describe('when called without path', () => {

--- a/src/read-folder/index.js
+++ b/src/read-folder/index.js
@@ -1,12 +1,20 @@
 /* global Promise */
 
 const {readdir} = require('fs');
+const { extname: pathExtname, dirname: pathDirname } = require('path');
 const promise = require('../promises/promise');
 
 const promiseReaddir = promise(readdir);
 
+// dirname : String -> String
+const dirname = path =>
+  pathExtname(path)
+    ? pathDirname(path)
+    : path;
+
+
 const readFolder = path =>
-  promiseReaddir(path, 'utf8');
+  promiseReaddir(dirname(path), 'utf8');
 
 
 module.exports = readFolder;

--- a/src/read-folder/index.js
+++ b/src/read-folder/index.js
@@ -1,17 +1,10 @@
 /* global Promise */
 
 const {readdir} = require('fs');
-const { extname: pathExtname, dirname: pathDirname } = require('path');
+const dirname = require('../dirname');
 const promise = require('../promises/promise');
 
 const promiseReaddir = promise(readdir);
-
-// dirname : String -> String
-const dirname = path =>
-  pathExtname(path)
-    ? pathDirname(path)
-    : path;
-
 
 const readFolder = path =>
   promiseReaddir(dirname(path), 'utf8');

--- a/src/read-folder/index.test.js
+++ b/src/read-folder/index.test.js
@@ -6,8 +6,8 @@ const fs = require('fs');
 const readFolder = require('./');
 
 describe('readFolder', () => {
-  describe('given existing path', () => {
-    it('should resolve with array of folder entries', () => {
+  describe('given path to folder', () => {
+    it('should resolve with array of filenames', () => {
       fs.__setFS({
         'folder-name': {
           'file.js': '',
@@ -16,6 +16,20 @@ describe('readFolder', () => {
       });
 
       return expect(readFolder('folder-name')).resolves.toEqual(['file.js', 'folder']);
+    });
+  });
+
+  describe('given path to file', () => {
+    it('should should resolve with array of filename', () => {
+      fs.__setFS({
+        folder: {
+          'index.js': '',
+          'some-file': '',
+          another_folder: {}
+        }
+      });
+
+      return expect(readFolder('folder/index.js')).resolves.toEqual(['index.js', 'some-file', 'another_folder']);
     });
   });
 


### PR DESCRIPTION
this in turn fixes `wix-storybook-utils` to support stories configured with `componentPath: 'path/to/component.js` and  as well as `componentPath: 'folder/of/component'`