### PR TITLE
read_file: add missing throw

### DIFF
--- a/src/read-file/index.js
+++ b/src/read-file/index.js
@@ -45,8 +45,9 @@ const readEntryFile = path =>
     .catch(isDirError =>
       tryReadWithExtension(path)
         .then(({ path }) => path)
-        .catch(e =>
-          new Error(`ERROR: Unable to read component entry file at "${path}". ${e} ${isDirError}`)
+        .catch(e => {
+            throw new Error(`ERROR: Unable to read component entry file at "${path}". ${e} ${isDirError}`);
+          }
         )
     )
 


### PR DESCRIPTION
Without this missing `thorw`, then when an error occus an Error object is returned, and the following `.catch()` block tries to use this error object as the `path`