### PR TITLE
Add JSDoc tags parsing (using `doctrine`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/parser": "7.0.0",
     "@babel/traverse": "7.0.0",
     "@babel/types": "7.0.0",
+    "doctrine": "^3.0.0",
     "react-docgen": "^3.0.0-rc.2",
     "react-docgen-typescript": "1.6.3",
     "recast": "0.13.0",

--- a/src/testkit-parser/tests/comments.test.js
+++ b/src/testkit-parser/tests/comments.test.js
@@ -18,7 +18,7 @@ describe('get method comments', () => {
         /** method description within block */
         method: () => {}
       })`,
-      expected: [{ name: 'method', type: 'function', args: [], description: 'method description within block' }],
+      expected: [{ name: 'method', type: 'function', args: [], description: 'method description within block' , tags: []}],
     },
     {
       spec: 'multi-line block comment',
@@ -29,7 +29,7 @@ describe('get method comments', () => {
          */
         method: () => {}
       })`,
-      expected: [{ name: 'method', type: 'function', args: [], description: 'method description within block' }],
+      expected: [{ name: 'method', type: 'function', args: [], description: 'method description within block', tags: [] }],
     },
     {
       spec: 'multiple comments',
@@ -66,6 +66,7 @@ within multiple comments`,
           args: [],
           description: 'Focus related testing is done in e2e tests only.',
           isDeprecated: true,
+          tags: [{description: null, title: 'deprecated'}]
         },
       ],
     },
@@ -88,4 +89,52 @@ within multiple comments`,
       expect(result).toEqual(expected);
     });
   });
+
+  describe('jsdoc tags', () => {
+    it('@param', async () => {
+      const result = await getExport(`
+      export default () => ({
+        /** 
+         * method description within block 
+         * @param {string} txt a param description
+         */
+        method: () => {}
+      })`);
+      expect(result).toEqual([{
+        name: 'method',
+        type: 'function',
+        args: [],
+        description: 'method description within block' ,
+        tags: [{
+          title: 'param',
+          name: 'txt',
+          description : 'a param description',
+          type: {name: 'string', type: 'NameExpression'}
+        }]
+      }]);
+    });
+
+    it('@returns', async () => {
+      const result = await getExport(`
+      export default () => ({
+        /** 
+         * method description within block 
+         * @returns {boolean} true or false
+         */
+        method: () => {}
+      })`);
+      expect(result).toEqual([{
+        name: 'method',
+        type: 'function',
+        args: [],
+        description: 'method description within block' ,
+        tags: [{
+          title: 'returns',
+          description : 'true or false',
+          type: {name: 'boolean', type: 'NameExpression'}
+        }]
+      }]);
+    });
+  })
+  
 });


### PR DESCRIPTION
[`doctrine`](https://github.com/eslint/doctrine) is a not-maintained-anymore library (developed by `eslint` guys)
It is stable, and should be enough for our needs.
(Maybe its a good thing, it means it won't break, cause its a read-only repo)

All I want now is to support `@param` and `@returns` JSDoc tags.

- I made it so that it uses doctrine only if there is exactly 1 leading comment and it is a `CommentBlock`, otherwise we fallback to the old parsing logic.

## Question to Arijus

Does `react-autodocs-utils` do both typescript and JS "parsing"?
Meaning that the output method descriptor should be a "consolidation" of:
 [typescript | JS] + JSDoc