### PR TITLE
Gather `README.API.md` files with the component metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2018-12-19
+### Added
+- Gather `README.API.md` files with the component metadata [#14](https://github.com/wix/react-autodocs-utils/pull/14)
+
+
 ## [3.3.0] - 2018-12-18
 ### Added
 - support jsdoc type of annotations in testkit comments [#13](https://github.com/wix/react-autodocs-utils/pull/13)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autodocs-utils",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Set of utilities for extracting meta information about react components mostly to generate automated documentation",
   "main": "index.js",
   "scripts": {

--- a/src/gather-all/index.js
+++ b/src/gather-all/index.js
@@ -39,14 +39,16 @@ const gatherAll = path =>
           .catch(() => Promise.resolve(''));
 
       const readme = readMarkdown('readme.md');
+      const readmeApi = readMarkdown('readme.api.md');
       const readmeAccessibility = readMarkdown('readme.accessibility.md');
       const readmeTestkit = readMarkdown('readme.testkit.md');
       const drivers = scanFiles(files.map(file => pathJoin(dirname(path), file)), { basename: true });
 
-      return Promise.all([metadata, readme, readmeAccessibility, readmeTestkit, drivers]).then(
-        ([metadata, readme, readmeAccessibility, readmeTestkit, drivers]) => ({
+      return Promise.all([metadata, readme, readmeApi, readmeAccessibility, readmeTestkit, drivers]).then(
+        ([metadata, readme, readmeApi, readmeAccessibility, readmeTestkit, drivers]) => ({
           ...metadata,
           readme,
+          readmeApi,
           readmeAccessibility,
           readmeTestkit,
           drivers,

--- a/src/gather-all/index.test.js
+++ b/src/gather-all/index.test.js
@@ -27,6 +27,7 @@ const metadataMock = {
 };
 
 const readmeMock = '# Hello readme!';
+const readmeApiMock = '# Hello API!';
 const readmeAccessibilityMock = '# Hello Accessiblity!';
 const readmeTestkitMock = '# Hello Testkit!';
 
@@ -44,12 +45,13 @@ describe('gatherAll', () => {
       });
     });
 
-    describe('which is folder with index.js, README.md, README.accessibility.md and README.testkit.md', () => {
+    describe('which is folder with index.js, README.md, README.api.md, README.accessibility.md and README.testkit.md', () => {
       it('should resolve with component metadata', () => {
         fs.__setFS({
           'component-folder': {
             'index.js': componentSourceMock,
             'readme.md': readmeMock,
+            'readme.api.md': readmeApiMock,
             'readme.accessibility.md': readmeAccessibilityMock,
             'readme.testkit.md': readmeTestkitMock,
           },
@@ -59,6 +61,7 @@ describe('gatherAll', () => {
           ...metadataMock,
           displayName: 'component',
           readme: readmeMock,
+          readmeApi: readmeApiMock,
           readmeAccessibility: readmeAccessibilityMock,
           readmeTestkit: readmeTestkitMock,
           drivers: [],
@@ -72,6 +75,7 @@ describe('gatherAll', () => {
           'component-folder': {
             'index.js': componentSourceMock,
             'README.md': readmeMock,
+            'readme.API.md': readmeApiMock,
             'readme.accessibility.md': readmeAccessibilityMock,
             'README.testkit.md': readmeTestkitMock,
           },
@@ -81,6 +85,7 @@ describe('gatherAll', () => {
           ...metadataMock,
           displayName: 'component',
           readme: readmeMock,
+          readmeApi: readmeApiMock,
           readmeAccessibility: readmeAccessibilityMock,
           readmeTestkit: readmeTestkitMock,
           drivers: [],
@@ -135,6 +140,7 @@ describe('gatherAll', () => {
             },
           },
           readme: '',
+          readmeApi: '',
           readmeAccessibility: '',
           readmeTestkit: '',
           drivers: [],
@@ -155,6 +161,7 @@ describe('gatherAll', () => {
             `,
 
             'readme.md': readmeMock,
+            'readme.api.md': readmeApiMock,
             'readme.accessibility.md': readmeAccessibilityMock,
             'readme.testkit.md': readmeTestkitMock,
           },
@@ -175,6 +182,7 @@ describe('gatherAll', () => {
           ...metadataMock,
           displayName: 'component',
           readme: readmeMock,
+          readmeApi: readmeApiMock,
           readmeAccessibility: readmeAccessibilityMock,
           readmeTestkit: readmeTestkitMock,
           drivers: [],
@@ -201,6 +209,7 @@ describe('gatherAll', () => {
                   }`,
 
                 'readme.md': readmeMock,
+                'readme.api.md': readmeApiMock,
                 'readme.accessibility.md': readmeAccessibilityMock,
                 'readme.testkit.md': readmeTestkitMock,
               },
@@ -258,6 +267,7 @@ describe('gatherAll', () => {
             },
           },
           readme: readmeMock,
+          readmeApi: readmeApiMock,
           readmeAccessibility: readmeAccessibilityMock,
           readmeTestkit: readmeTestkitMock,
           drivers: [],
@@ -270,6 +280,7 @@ describe('gatherAll', () => {
         fs.__setFS({
           'index.js': componentSourceMock,
           'readme.md': readmeMock,
+          'readme.api.md': readmeApiMock,
           'readme.accessibility.md': readmeAccessibilityMock,
           'readme.testkit.md': readmeTestkitMock,
         });
@@ -278,6 +289,7 @@ describe('gatherAll', () => {
           ...metadataMock,
           displayName: 'component',
           readme: readmeMock,
+          readmeApi: readmeApiMock,
           readmeAccessibility: readmeAccessibilityMock,
           readmeTestkit: readmeTestkitMock,
           drivers: [],


### PR DESCRIPTION
This is in order to support having `README.API.md` files alongside the component, then `<StoryPage/>` will be able to show this markdown above the generated `<AutoDocs/>`.