### PR TITLE
feat(prepareStory): support ES5

### DIFF
--- a/src/metadata-merger/index.test.js
+++ b/src/metadata-merger/index.test.js
@@ -3,10 +3,6 @@
 const metadataMerger = require('./');
 
 describe('metadataMerger', () => {
-  it('should return function', () => {
-    expect(typeof metadataMerger()).toBe('function');
-  });
-
   describe('when erroneous input given', () => {
     it('should reject promise with message', () =>
       expect(metadataMerger()()).rejects.toEqual(
@@ -19,10 +15,11 @@ describe('metadataMerger', () => {
       expect(metadataMerger('"test"')({}).then).toBeDefined();
     });
 
-    it('should add `_metadata` to story config', () => {
-      const source = 'export default { a: 1, b: 2 }';
-      const metadata = { hello: 1, goodbye: { forReal: 'bye' } };
-      const expectation = `export default {
+    describe('when export default', () => {
+      it('should add `_metadata` to story config', () => {
+        const source = 'export default { a: 1, b: 2 }';
+        const metadata = { hello: 1, goodbye: { forReal: 'bye' } };
+        const expectation = `export default {
   a: 1,
   b: 2,
   _metadata: {
@@ -33,16 +30,16 @@ describe('metadataMerger', () => {
   }
 };`;
 
-      return expect(metadataMerger(source)(metadata)).resolves.toEqual(expectation);
-    });
+        return expect(metadataMerger(source)(metadata)).resolves.toEqual(expectation);
+      });
 
-    it('should add `_metadata` to referenced story config', () => {
-      const source = `
+      it('should add `_metadata` to referenced story config', () => {
+        const source = `
         const config = { a: 1, b: { c: 2 } };
         export default config;
       `;
-      const metadata = { whatIs: 'love' };
-      const expectation = `const config = {
+        const metadata = { whatIs: 'love' };
+        const expectation = `const config = {
   a: 1,
   b: {
     c: 2
@@ -53,7 +50,47 @@ describe('metadataMerger', () => {
 };
 export default config;`;
 
-      return expect(metadataMerger(source)(metadata)).resolves.toEqual(expectation);
+        return expect(metadataMerger(source)(metadata)).resolves.toEqual(expectation);
+      });
+    });
+
+    describe('when module.exports', () => {
+      it('should add `_metadata` to story config', () => {
+        const source = 'module.exports = { a: 1, b: 2 }';
+        const metadata = { hello: 1, goodbye: { forReal: 'bye' } };
+        const expectation = `module.exports = {
+  a: 1,
+  b: 2,
+  _metadata: {
+    "hello": 1,
+    "goodbye": {
+      "forReal": "bye"
+    }
+  }
+};`;
+
+        return expect(metadataMerger(source)(metadata)).resolves.toEqual(expectation);
+      });
+
+      it('should add `_metadata` to referenced story config', () => {
+        const source = `
+        const config = { a: 1, b: { c: 2 } };
+        module.exports = config;
+      `;
+        const metadata = { whatIs: 'love' };
+        const expectation = `const config = {
+  a: 1,
+  b: {
+    c: 2
+  },
+  _metadata: {
+    "whatIs": "love"
+  }
+};
+module.exports = config;`;
+
+        return expect(metadataMerger(source)(metadata)).resolves.toEqual(expectation);
+      });
     });
   });
 

--- a/src/path-finder/index.js
+++ b/src/path-finder/index.js
@@ -13,53 +13,67 @@ const pathFinder = (source = '') => {
   const ast = parse(source);
 
   return new Promise((resolve, reject) => {
+    const extractComponentPath = (path, node) => {
+      if (types.isObjectExpression(node)) {
+        const getValue = key => extractKeyFromObject(node)(key);
+        const componentPath = getValue('componentPath');
+
+        if (componentPath) {
+          return resolve(componentPath.value.value);
+        } else {
+          const componentReference = get(getValue('component'))('value.name');
+
+          if (!componentReference) {
+            return resolve(null);
+          }
+
+          visit(ast)({
+            ImportDeclaration(path) {
+              const componentPath = get(path)('node.specifiers').find(
+                ({ local: { name } }) => name === componentReference
+              );
+
+              if (componentPath) {
+                resolve(get(path)('node.source.value'));
+                return false;
+              }
+            },
+          });
+
+          resolve(componentReference);
+        }
+      }
+
+      if (types.isIdentifier(node)) {
+        const binding = path.scope.bindings[node.name];
+
+        if (binding) {
+          visit(ast)({
+            VariableDeclarator(path) {
+              if (types.isIdentifier(binding.identifier, { name: binding.identifier.name })) {
+                const componentPath = extractKeyFromObject(path.node.init)('componentPath').value.value;
+                resolve(componentPath);
+              }
+            },
+          });
+        }
+      }
+    };
+
     visit(ast)({
       ExportDefaultDeclaration(path) {
-        const declaration = path.node.declaration;
+        extractComponentPath(path, path.node.declaration);
+      },
 
-        if (types.isObjectExpression(declaration)) {
-          const getValue = key => extractKeyFromObject(declaration)(key);
-          const componentPath = getValue('componentPath');
+      ExpressionStatement(path) {
+        const isModuleExports = [
+          types.isMemberExpression(path.node.expression.left),
+          get(path)('node.expression.left.object.name') === 'module',
+          get(path)('node.expression.left.property.name') === 'exports',
+        ].every(Boolean);
 
-          if (componentPath) {
-            return resolve(componentPath.value.value);
-          } else {
-            const componentReference = get(getValue('component'))('value.name');
-
-            if (!componentReference) {
-              return resolve(null);
-            }
-
-            visit(ast)({
-              ImportDeclaration(path) {
-                const componentPath = get(path)('node.specifiers').find(
-                  ({ local: { name } }) => name === componentReference
-                );
-
-                if (componentPath) {
-                  resolve(get(path)('node.source.value'));
-                  return false;
-                }
-              },
-            });
-
-            resolve(componentReference);
-          }
-        }
-
-        if (types.isIdentifier(declaration)) {
-          const binding = path.scope.bindings[declaration.name];
-
-          if (binding) {
-            visit(ast)({
-              VariableDeclarator(path) {
-                if (types.isIdentifier(binding.identifier, { name: binding.identifier.name })) {
-                  const componentPath = extractKeyFromObject(path.node.init)('componentPath').value.value;
-                  resolve(componentPath);
-                }
-              },
-            });
-          }
+        if (isModuleExports) {
+          extractComponentPath(path, path.node.expression.right);
         }
       },
     });

--- a/src/path-finder/index.test.js
+++ b/src/path-finder/index.test.js
@@ -22,6 +22,25 @@ describe('pathFinder()', () => {
     );
   });
 
+  describe('given `componentPath` in `module.exports`', () => {
+    const path = '.' + 'hello'.repeat(Math.random() * 19);
+
+    const sourceTestCases = [
+      `module.exports = { componentPath: '${path}' }`,
+
+      `const config = {
+        componentPath: '${path}'
+      };
+      module.exports = config;
+      `,
+    ];
+
+    sourceTestCases.map(source =>
+      it('should resolve promise with value of `componentPath`', () =>
+        expect(pathFinder(source)).resolves.toEqual(path))
+    );
+  });
+
   describe('given incomplete story config', () => {
     it('should return null', () => {
       const source = 'export default { sections: [] };';

--- a/src/prepare-story/index.js
+++ b/src/prepare-story/index.js
@@ -6,18 +6,6 @@ const parse = require('../parser/parse');
 const print = require('../parser/print');
 const get = require('../get');
 
-const buildImportDeclaration = (specifier, path) => types.importDeclaration([specifier], types.stringLiteral(path));
-const buildRequireExpression = (identifier, path) => {
-  const id = types.identifier(identifier);
-
-  return types.variableDeclaration('const', [
-    types.variableDeclarator(
-      types.objectPattern([types.objectProperty(id, id, /*computed*/ false, /*shorthand*/ true)]),
-      types.callExpression(types.identifier('require'), [types.stringLiteral(path)])
-    ),
-  ]);
-};
-
 const prepareStory = storyConfig => source =>
   new Promise((resolve, reject) =>
     source && !!storyConfig

--- a/src/prepare-story/index.js
+++ b/src/prepare-story/index.js
@@ -4,8 +4,16 @@ const types = require('@babel/types');
 const visit = require('../parser/visit');
 const parse = require('../parser/parse');
 const print = require('../parser/print');
+const get = require('../get');
 
 const buildImportDeclaration = (specifier, path) => types.importDeclaration([specifier], types.stringLiteral(path));
+
+const isModuleExports = path =>
+  [
+    types.isMemberExpression(path.node.expression.left),
+    get(path)('node.expression.left.object.name') === 'module',
+    get(path)('node.expression.left.property.name') === 'exports',
+  ].every(Boolean);
 
 const prepareStory = storyConfig => source =>
   new Promise((resolve, reject) =>
@@ -16,18 +24,55 @@ const prepareStory = storyConfig => source =>
 
     .then(parse)
 
-    // add necessary imports
     .then(ast => {
-      ast.program.body.unshift(
-        buildImportDeclaration(
-          types.importSpecifier(types.identifier('storiesOf'), types.identifier('storiesOf')),
-          '@storybook/react'
-        )
-      );
+      let isES5 = true;
 
-      ast.program.body.unshift(
-        buildImportDeclaration(types.importDefaultSpecifier(types.identifier('story')), 'wix-storybook-utils/Story')
-      );
+      visit(ast)({
+        ExportDefaultDeclaration() {
+          isES5 = false;
+          return false;
+        },
+      });
+
+      if (isES5) {
+        // add requires
+        const storyId = types.identifier('story');
+        const storiesOfId = types.identifier('storiesOf');
+        const requireId = types.identifier('require');
+        const wsuImportPath = types.stringLiteral('wix-storybook-utils/Story');
+        const storiesOfImportPath = types.stringLiteral('@storybook/react');
+
+        // const { storiesOf } = require("@storybook/react");
+        ast.program.body.unshift(
+          types.variableDeclaration('const', [
+            types.variableDeclarator(
+              types.objectPattern([
+                types.objectProperty(storiesOfId, storiesOfId, /*computed*/ false, /*shorthand*/ true),
+              ]),
+              types.callExpression(requireId, [storiesOfImportPath])
+            ),
+          ])
+        );
+
+        // const story = require('wix-storybook-utils/Story')
+        ast.program.body.unshift(
+          types.variableDeclaration('const', [
+            types.variableDeclarator(storyId, types.callExpression(requireId, [wsuImportPath])),
+          ])
+        );
+      } else {
+        // add necessary imports
+        ast.program.body.unshift(
+          buildImportDeclaration(
+            types.importSpecifier(types.identifier('storiesOf'), types.identifier('storiesOf')),
+            '@storybook/react'
+          )
+        );
+
+        ast.program.body.unshift(
+          buildImportDeclaration(types.importDefaultSpecifier(types.identifier('story')), 'wix-storybook-utils/Story')
+        );
+      }
 
       return ast;
     })
@@ -37,57 +82,60 @@ const prepareStory = storyConfig => source =>
       // rejected promise from within visitor, babylon complains
       let error = null;
 
+      const configAST = parse(`(${JSON.stringify(storyConfig)})`);
+      let configProperties;
+
+      visit(configAST)({
+        ObjectExpression(path) {
+          const storiesOfProperty = types.objectProperty(types.identifier('storiesOf'), types.identifier('storiesOf'));
+
+          path.node.properties.push(storiesOfProperty);
+
+          configProperties = path.node.properties;
+          path.stop();
+        },
+      });
+
+      const handleExportObject = (path, node) => {
+        const exportsObject = types.isObjectExpression(node);
+        const exportsIdentifier = types.isIdentifier(node);
+
+        if (exportsIdentifier) {
+          const referenceName = node.name;
+          const configObject = path.scope.bindings[referenceName].path.node.init;
+
+          if (!configObject.properties) {
+            error = `ERROR: storybook config must export an object, exporting ${configObject.type} instead`;
+            return false;
+          }
+
+          configObject.properties.push(
+            types.objectProperty(types.identifier('_config'), types.objectExpression(configProperties))
+          );
+
+          return types.callExpression(types.identifier('story'), [node]);
+        }
+
+        if (exportsObject) {
+          node.properties.push(
+            types.objectProperty(types.identifier('_config'), types.objectExpression(configProperties))
+          );
+
+          // wrap exported object with `story()`
+          return types.callExpression(types.identifier('story'), [node]);
+        }
+      };
+
       visit(ast)({
         ExportDefaultDeclaration(path) {
-          const exportsObject = types.isObjectExpression(path.node.declaration);
-          const exportsReference = types.isIdentifier(path.node.declaration);
-
-          // add `_config` to exported object
-          const configAST = parse(`(${JSON.stringify(storyConfig)})`);
-          let configProperties;
-
-          visit(configAST)({
-            ObjectExpression(path) {
-              const storiesOfProperty = types.objectProperty(
-                types.identifier('storiesOf'),
-                types.identifier('storiesOf')
-              );
-
-              path.node.properties.push(storiesOfProperty);
-
-              configProperties = path.node.properties;
-              path.stop();
-            },
-          });
-
-          if (exportsReference) {
-            const referenceName = path.node.declaration.name;
-            const configObject = path.scope.bindings[referenceName].path.node.init;
-
-            if (!configObject.properties) {
-              error = `ERROR: storybook config must export an object, exporting ${configObject.type} instead`;
-              return false;
-            }
-
-            configObject.properties.push(
-              types.objectProperty(types.identifier('_config'), types.objectExpression(configProperties))
-            );
-
-            path.node.declaration = types.callExpression(types.identifier('story'), [path.node.declaration]);
-          }
-
-          if (exportsObject) {
-            const configObject = path.node.declaration;
-
-            configObject.properties.push(
-              types.objectProperty(types.identifier('_config'), types.objectExpression(configProperties))
-            );
-
-            // wrap exported object with `story()`
-            path.node.declaration = types.callExpression(types.identifier('story'), [configObject]);
-          }
-
+          path.node.declaration = handleExportObject(path, path.node.declaration);
           return false;
+        },
+
+        ExpressionStatement(path) {
+          if (isModuleExports(path)) {
+            path.node.expression.right = handleExportObject(path, path.node.expression.right);
+          }
         },
       });
 

--- a/src/prepare-story/index.test.js
+++ b/src/prepare-story/index.test.js
@@ -25,7 +25,9 @@ export default something;`;
     it('should wrap exported object with `story()`', () => {
       const source = 'export default { a: 1 };';
       const expectation = `import story from "wix-storybook-utils/Story";
+
 import { storiesOf } from "@storybook/react";
+
 export default story({
   a: 1,
   _config: {
@@ -40,7 +42,9 @@ export default story({
       const source = 'export default { a: 1 };';
       const config = { a: 1 };
       const expectation = `import story from "wix-storybook-utils/Story";
+
 import { storiesOf } from "@storybook/react";
+
 export default story({
   a: 1,
   _config: {
@@ -59,7 +63,9 @@ export default story({
       `;
       const config = { hello: 'config!', time: { to: { say: { good: 'buy' } } } };
       const expectation = `import story from "wix-storybook-utils/Story";
+
 import { storiesOf } from "@storybook/react";
+
 const config = {
   a: 1,
   b: {
@@ -97,7 +103,9 @@ export default story(config);`;
       const config = { 'i-am-config': 'yes' };
 
       const expectation = `import story from "wix-storybook-utils/Story";
+
 import { storiesOf } from "@storybook/react";
+
 const stuff = {
   thing: {
     moreThings: ['hello']
@@ -149,7 +157,9 @@ export default story({
       };
 
       const expectation = `import story from "wix-storybook-utils/Story";
+
 import { storiesOf } from "@storybook/react";
+
 const stuff = {
   thing: {
     moreThings: ['hello']
@@ -189,7 +199,7 @@ export default story({
     it('should work with module.exports', () => {
       const source = 'module.exports = { a: 1 };';
       const config = { a: 1 };
-      const expectation = `const story = require("wix-storybook-utils/Story");
+      const expectation = `const story = require("wix-storybook-utils/Story").default;
 
 const {
   storiesOf
@@ -239,7 +249,7 @@ module.exports = story({
         },
       };
 
-      const expectation = `const story = require("wix-storybook-utils/Story");
+      const expectation = `const story = require("wix-storybook-utils/Story").default;
 
 const {
   storiesOf

--- a/src/prepare-story/index.test.js
+++ b/src/prepare-story/index.test.js
@@ -3,11 +3,7 @@
 const prepareStory = require('./');
 
 describe('prepareStory', () => {
-  it('should be a function', () => {
-    expect(typeof prepareStory).toBe('function');
-  });
-
-  describe('when erroneous input given', () => {
+  describe('given erroneous input', () => {
     it('should reject promise with message', () =>
       expect(prepareStory()()).rejects.toEqual(
         'ERROR: unable to prepare story, both `storyConfig` and `source` must be provided'
@@ -186,6 +182,102 @@ export default story({
     storiesOf: storiesOf
   }
 });`;
+
+      return expect(prepareStory(config)(source)).resolves.toEqual(expectation);
+    });
+
+    it('should work with module.exports', () => {
+      const source = 'module.exports = { a: 1 };';
+      const config = { a: 1 };
+      const expectation = `const story = require("wix-storybook-utils/Story");
+
+const {
+  storiesOf
+} = require("@storybook/react");
+
+module.exports = story({
+  a: 1,
+  _config: {
+    "a": 1,
+    storiesOf: storiesOf
+  }
+});`;
+
+      return expect(prepareStory(config)(source)).resolves.toEqual(expectation);
+    });
+
+    it('should work with referenced module.exports', () => {
+      const source = `
+        const stuff = { thing: { moreThings: ['hello'] } };
+        const callMe = () => true;
+        const reference = {
+          a: 1,
+          b: {
+            ...stuff,
+            c: ['d']
+          },
+          d: {
+            e: {
+              f: {
+                hello: callMe('maybe')
+              }
+            }
+          }
+        };
+
+        module.exports = reference;
+      `;
+
+      const config = {
+        'i-am-config': 'yes',
+        nested: {
+          oh: {
+            boy: {
+              thing: 'hey there!',
+            },
+          },
+        },
+      };
+
+      const expectation = `const story = require("wix-storybook-utils/Story");
+
+const {
+  storiesOf
+} = require("@storybook/react");
+
+const stuff = {
+  thing: {
+    moreThings: ['hello']
+  }
+};
+
+const callMe = () => true;
+
+const reference = {
+  a: 1,
+  b: { ...stuff,
+    c: ['d']
+  },
+  d: {
+    e: {
+      f: {
+        hello: callMe('maybe')
+      }
+    }
+  },
+  _config: {
+    "i-am-config": "yes",
+    "nested": {
+      "oh": {
+        "boy": {
+          "thing": "hey there!"
+        }
+      }
+    },
+    storiesOf: storiesOf
+  }
+};
+module.exports = story(reference);`;
 
       return expect(prepareStory(config)(source)).resolves.toEqual(expectation);
     });


### PR DESCRIPTION
augment code when used with `module.exports`.
in that case also use `require` for dependencies (instead of `import`)